### PR TITLE
Add bundlephobia-checker action to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@
 - [badgen.net](https://badgen.net/#bundlephobia) - example size of react: ![react](https://badgen.net/bundlephobia/minzip/react)
 - [shields.io](https://shields.io/#/examples/size) - example size of react: ![react](https://img.shields.io/bundlephobia/minzip/react.svg)
 
+## Github Actions
+
+- [check-my-bundlephobia](https://github.com/marketplace/actions/bundlephobia-checker) - Check new and modified added packages on bundlephobia
+
 ## Built using bundlephobia
 - Size in browser - As seen on package searches at [yarnpkg.com](https://yarnpkg.com)
 - [bundlephobia-cli](https://github.com/AdrieanKhisbe/bundle-phobia-cli) - A Command Line client for bundlephobia


### PR DESCRIPTION
Hello I've created[ this github action](https://github.com/marketplace/actions/bundlephobia-checker) for the github actions hackaton and I'll be glad to have it in your readme. Some docs:

# check-my-bundlephobia 😱

Check my bundlephobia is a github action that will check for your code changes on a PR and will left a comment with the different sizes.


## How to use it

```yml
name: "check my bundlephobia"
on:
  push:
    branches:
      - master
  pull_request:
    branches:
      - master
jobs:
  bundlecheck:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v1
      - uses: carlesnunez/check-my-bundlephobia
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
          strict: true
          threshold: 500
```

## Options

| name       | description                                        | required | type    | default |
| ---------- | -------------------------------------------------- | -------- | ------- | ------- |
| repo-token | used by the action in order to perform PR reviews  | true     |         |         |
| strict     | If true will reject the PR if threshold is exceded | false    | Boolean | false   |
| threshold  | Max package size in bytes                          | false    | String  | 500     |

